### PR TITLE
Fix HD-BET dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/MIC-DKFZ/HD-BET.git#egg=HD-BET
+HD-BET==1.1
 git+https://github.com/JThoennissen/siibra-explorer-toolsuite.git@v0.0.1#egg=siibra-explorer-toolsuite
 siibra==0.4a59
 tkfontawesome==0.2.0


### PR DESCRIPTION
HD-BET was updated to v2 in October 2024. Voluba-MRIWrap can currently only run HD-BET v1, as hd_bet.run and hd_bet.utils were removed in v2. Since 2024 HD-BET can be retrieved via PIP.

The first commit to HD-BET v2 for reference:
https://github.com/MIC-DKFZ/HD-BET/commit/27414b2ef60167bce8a5ae5a1a34e8b02bb2d7d6

The PIP project:
https://pypi.org/project/HD-BET/